### PR TITLE
[CLOUDTRUST-2816] Get realm configuration from account

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -105,3 +105,18 @@ func (c *AccountClient) SendEmail(accessToken, realmName, template, subject stri
 	_, err := c.client.post(accessToken, nil, plugins...)
 	return err
 }
+
+// GetRealm get the top level represention of the realm. Nested information like users are
+// not included.
+func (c *AccountClient) GetRealm(accessToken string, realmName string) (keycloak.AccountRealmRepresentation, error) {
+	var conf = keycloak.RealmRepresentation{}
+	if err := c.client.get(accessToken, &conf, url.Path(realmPath), url.Param("realm", realmName)); err != nil {
+		return keycloak.AccountRealmRepresentation{}, err
+	}
+	return keycloak.AccountRealmRepresentation{
+		ID:               conf.ID,
+		DisplayName:      conf.DisplayName,
+		DefaultLocale:    conf.DefaultLocale,
+		SupportedLocales: conf.SupportedLocales,
+	}, nil
+}

--- a/definitions.go
+++ b/definitions.go
@@ -517,6 +517,14 @@ type RealmRepresentation struct {
 	WaitIncrementSeconds                *int32                                  `json:"waitIncrementSeconds,omitempty"`
 }
 
+// AccountRealmRepresentation struct
+type AccountRealmRepresentation struct {
+	ID               *string   `json:"id,omitempty"`
+	DisplayName      *string   `json:"displayName,omitempty"`
+	DefaultLocale    *string   `json:"defaultLocale,omitempty"`
+	SupportedLocales *[]string `json:"supportedLocales,omitempty"`
+}
+
 // RequiredActionProviderRepresentation struct
 type RequiredActionProviderRepresentation struct {
 	Alias         *string                 `json:"alias,omitempty"`


### PR DESCRIPTION
Not used as we need a technical JWT token to get realm configuration